### PR TITLE
Prefill default configuration in generate-config

### DIFF
--- a/generate-config.py
+++ b/generate-config.py
@@ -27,17 +27,13 @@
 ##****************************************************************************
 
 
-
 import datetime
 import os
 import pwd
 import readline
 import tempfile
 
-
-
 config_dict = dict()
-
 
 
 # https://eli.thegreenplace.net/2016/basics-of-using-the-readline-library/
@@ -45,8 +41,8 @@ def make_completer(vocabulary):
     def custom_complete(text, state):
         results = [x for x in vocabulary if x.startswith(text)] + [None]
         return results[state] + ' '
-    return custom_complete
 
+    return custom_complete
 
 
 def initialize_readline():
@@ -60,10 +56,9 @@ def initialize_readline():
     readline.set_completer(make_completer(vocabulary))
 
 
-
-def write_key_value_pair(key, conf_file, suffix_slash = False):
-    val =  input('{0}: '.format(key)).strip()
-
+def write_key_value_pair(key, conf_file, suffix_slash=False, prefill=""):
+    val = input('{0}: '.format(key)).strip() or prefill
+    print(val)
     if suffix_slash == True:
         if not val.endswith('/'):
             val += '/'
@@ -74,21 +69,21 @@ def write_key_value_pair(key, conf_file, suffix_slash = False):
     return val
 
 
-
 def create_configuration_file():
     # Create configuration file in $HOME
     rc_path = os.path.expanduser('~') + '/.helpcovidrc'
-    if os.access (rc_path, os.F_OK):  os.rename (rc_path, rc_path + '~')
+    if os.access(rc_path, os.F_OK):  os.rename(rc_path, rc_path + '~')
     rc_file = open(rc_path, 'w')
 
     # Read web keys and save to config file
     rc_file.write('[web]\n\n')
     print("\n ==== HelpCovid web configuration =====\n")
     print("Enter web served URL, e.g. http://localhost:8089/ or https://example.com/\n")
-    write_key_value_pair('url', rc_file, True)
-    print("Enter web document root, a local directory containing web served resources (e.g. HTML files, CSS stylesheets)\n");
+    write_key_value_pair('url', rc_file, True, "http://localhost:8089/")
+    print(
+        "Enter web document root, a local directory containing web served resources (e.g. HTML files, CSS stylesheets)\n");
     print("... e.g. " + os.getcwd() + "/webroot/")
-    write_key_value_pair('root', rc_file, True)
+    write_key_value_pair('root', rc_file, True, os.getcwd() + "/webroot/")
     print("Enter the OpenSSL public certificate, for HTTPS - can be left empty; see https://www.openssl.org/\n")
     write_key_value_pair('sslcert', rc_file)
     print("Enter the OpenSSL private key, for HTTPS")
@@ -99,23 +94,25 @@ def create_configuration_file():
     rc_file.write('\n[postgresql]\n\n')
     print("Enter the PostGreSQL connnection string, see https://www.postgresql.org/docs/current/libpq-connect.html")
     print('Example: dbname=helpcovid_db user=helpcovid_usr'
-            ' password=passwd1234 hostaddr=127.0.0.1 port=5432')
-    conn = write_key_value_pair('connection', rc_file)
+          ' password=passwd1234 hostaddr=127.0.0.1 port=5432')
+    conn = write_key_value_pair('connection', rc_file,
+                                prefill="dbname=helpcovid_db user=helpcovid_usr password=passwd1234 hostaddr=127.0.0.1 port=5432")
     print('Enter *full path* of the HelpCovid PostgreSQL password file')
     print("... e.g. " + os.path.expanduser('~') + "/.helpcovid-pg-password")
-    config_dict['passfile'] = write_key_value_pair('passfile', rc_file)
+    config_dict['passfile'] = write_key_value_pair('passfile', rc_file,
+                                                   prefill=os.path.expanduser('~') + "/.helpcovid-pg-password")
 
     # Read HTML template tag keys
     print("\n ==== HelpCovid HTML template tags configuration ====\n")
     rc_file.write('\n[html]\n\n')
     print("Enter HTML for <?hcv_datacontroller?>")
     print('Example: <a href="mailto:john.doe@example.org>John Doe</a>')
-    write_key_value_pair("hcv_datacontroller_tag", rc_file)
+    write_key_value_pair("hcv_datacontroller_tag", rc_file, prefill='<a href="mailto:john.doe@example.org>John Doe</a>')
 
     # Generate timestamp
     ts = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
     rc_file.write('\n# generated on %s\n' % ts)
-    rc_file.write('# end of generated file ~/.helpcovidrc\n');
+    rc_file.write('# end of generated file ~/.helpcovidrc\n')
 
     # Ensure chmod 600
     rc_file.close()
@@ -126,7 +123,6 @@ def create_configuration_file():
     return conn
 
 
-
 def write_connection_keys(conn):
     split = conn.split()
 
@@ -135,15 +131,14 @@ def write_connection_keys(conn):
     config_dict['password'] = split[2].split('=')[1]
 
 
-
 def create_temp_sql():
-    sql_file, sql_path = tempfile.mkstemp(suffix = 'helpcovid', text = True)
+    sql_file, sql_path = tempfile.mkstemp(suffix='helpcovid', text=True)
     sql_file = open(sql_file, 'w')
 
     # https://stackoverflow.com/questions/18389124/
     sql = 'SELECT \'CREATE DATABASE {0}\' WHERE NOT EXISTS \
         (SELECT FROM pg_database WHERE datname = \'{0}\')\\gexec\n'.format(
-            config_dict['database'])
+        config_dict['database'])
     sql_file.write(sql)
 
     # https://stackoverflow.com/questions/8092086/
@@ -179,7 +174,6 @@ def create_temp_sql():
     return sql_path
 
 
-
 def create_database(sql_path):
     print('Creating database...')
     os.system('sudo -u postgres /usr/bin/psql -f ' + sql_path)
@@ -187,17 +181,15 @@ def create_database(sql_path):
     # os.remove(sql_path) <-- encounters permission error
 
 
-
 def create_password_file():
-    if os.access (config_dict['passfile'], os.F_OK):
-        os.rename (config_dict['passfile'], config_dict['passfile'] + '~')
+    if os.access(config_dict['passfile'], os.F_OK):
+        os.rename(config_dict['passfile'], config_dict['passfile'] + '~')
     pass_file = open(config_dict['passfile'], 'w')
     pass_file.write(config_dict['password'])
     pass_file.write("\n")
     pass_file.close()
 
     print('Password file created at ' + config_dict['passfile'])
-
 
 
 def check_postgres_exists():
@@ -207,11 +199,9 @@ def check_postgres_exists():
         print('postgres user not available. Please install PostgreSQL first...')
 
 
-
 def main():
     print('Starting HelpCovid configuration generator...')
     print('See https://github.com/bstarynk/helpcovid and its README.md\n')
-
 
     check_postgres_exists()
     initialize_readline()
@@ -223,7 +213,5 @@ def main():
     create_password_file()
 
 
-
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
Pressing "enter" at all choices in generate-config now uses the default (example) values. There might be an easier or nicer way to achieve this, but I just put in another optional argument at every choice. Ideally it should look like 
```
Enter web served URL, e.g. http://localhost:8089/ or https://example.com/

url [http://localhost:8089/]:
```
For now it does not display the default value, but you can actually create a new default configuration by just pressing enter at all choices for a quick installation:
```
root@c9cab6467046:/app/helpcovid# ./generate-config.py
Starting HelpCovid configuration generator...
See https://github.com/bstarynk/helpcovid and its README.md


 ==== HelpCovid web configuration =====

Enter web served URL, e.g. http://localhost:8089/ or https://example.com/

url:
http://localhost:8089/
[url = http://localhost:8089/]
Enter web document root, a local directory containing web served resources (e.g. HTML files, CSS stylesheets)

... e.g. /app/helpcovid/webroot/
root:
/app/helpcovid/webroot/
[root = /app/helpcovid/webroot/]
Enter the OpenSSL public certificate, for HTTPS - can be left empty; see https://www.openssl.org/

sslcert:

[sslcert = ]
Enter the OpenSSL private key, for HTTPS
sskey:

[sskey = ]

 ==== HelpCovid PostGreSQL database configuration, see https://www.postgresql.org/ ====

Enter the PostGreSQL connnection string, see https://www.postgresql.org/docs/current/libpq-connect.html
Example: dbname=helpcovid_db user=helpcovid_usr password=passwd1234 hostaddr=127.0.0.1 port=5432
connection:
dbname=helpcovid_db user=helpcovid_usr password=passwd1234 hostaddr=127.0.0.1 port=5432
[connection = dbname=helpcovid_db user=helpcovid_usr password=passwd1234 hostaddr=127.0.0.1 port=5432]
Enter *full path* of the HelpCovid PostgreSQL password file
... e.g. /root/.helpcovid-pg-password
passfile:
/root/.helpcovid-pg-password
[passfile = /root/.helpcovid-pg-password]

 ==== HelpCovid HTML template tags configuration ====

Enter HTML for <?hcv_datacontroller?>
Example: <a href="mailto:john.doe@example.org>John Doe</a>
hcv_datacontroller_tag:
<a href="mailto:john.doe@example.org>John Doe</a>
[hcv_datacontroller_tag = <a href="mailto:john.doe@example.org>John Doe</a>]

Configuration file saved to /root/.helpcovidrc]
Creating database...
psql:/tmp/tmpi8g5revvhelpcovid:8: NOTICE:  user already exists; skipping...
DO
ALTER ROLE
ALTER ROLE
ALTER ROLE
GRANT
removed '/tmp/tmpi8g5revvhelpcovid'
Password file created at /root/.helpcovid-pg-password
root@c9cab6467046:/app/helpcovid#
```