### PR TITLE
Add zxcvbn the password strength checker

### DIFF
--- a/webroot/html/register.html
+++ b/webroot/html/register.html
@@ -281,7 +281,8 @@
     <script src="https://cdn.jsdelivr.net/gh/Wruczek/Bootstrap-Cookie-Alert@gh-pages/cookiealert.js"></script>
     <!-- Select2 widget -->
     <script src="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/js/select2.min.js"></script>
-
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/zxcvbn/4.4.2/zxcvbn.js"></script>
+    
     <script type="javascript">
       $(document).ready(function () {
         $('select').select2();


### PR DESCRIPTION
Add a function which can check the strength of the password in JavaScript. It will return an object with details for example:

`zxcvbn("fizzbar42")`

Return object (probably we want to check the score attribute):
```

calc_time: 5
​
crack_times_display: Object { online_throttling_100_per_hour: "centuries", online_no_throttling_10_per_second: "3 years", offline_slow_hashing_1e4_per_second: "1 day", … }
​
crack_times_seconds: Object { online_throttling_100_per_hour: 36000000036, online_no_throttling_10_per_second: 100000000.1, offline_slow_hashing_1e4_per_second: 100000.0001, … }
​
feedback: Object { warning: "", suggestions: [] }
​
guesses: 1000000001
​
guesses_log10: 9.000000000434293
​
password: "fizzbar42"
​
score: 3
​
sequence: (1) […
```